### PR TITLE
Bump version of dependency eyeglass

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "mocha tests"
   },
   "dependencies": {
-    "eyeglass": "^0.2.0",
+    "eyeglass": "^0.6.3",
     "node-sass": "^3.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump version of dependency eyeglass to fix build error 
of sub-dependency deasync with newer node releases.
Pull Request for fixing issue https://github.com/danielguillan/modernizr-mixin/issues/26.